### PR TITLE
Fix a Bug of saving crt file.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -309,7 +309,7 @@ int main(int argc, char *argv[]) {
 	if(!endsWith(output, ".crt"))
 		output += ".crt";
 
-	FILE *file = fopen(output.c_str(), "w");
+	FILE *file = fopen(output.c_str(), "wb");
 	if(!file) {
 		cerr << "Couldl not open file: " << output << endl;
 		return 1;


### PR DESCRIPTION
In main.cpp line 312 the parameter of fopen is "w".The parameter should be "wb".the "w" is right in Linux but wrong in Windows.