### PR TITLE
Update CMakeList to set C++ standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(corto)
 
+set (CMAKE_CXX_STANDARD 11)
+
 SET(CORTO_SOURCE_PATH src)
 
 SET(LIB_HEADERS


### PR DESCRIPTION
Without it some compilers complain that c++11 features aren't available (such as `std::vector::emplace_back()`)