### PR TITLE
cmake script modernization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,12 @@ project(corto)
 option(BUILD_CORTO_CODEC_UNITY "Build the unity codec shared library of corto" ON)
 option(BUILD_CORTO_EXE "Build the command line binary of corto" ON)
 
-set (CMAKE_CXX_STANDARD 11)
+SET(CMAKE_CXX_STANDARD 11)
+SET(CMAKE_CXX_STANDARD_REQUIRED ON)
+SET(CMAKE_CXX_EXTENSIONS OFF)
 
-SET(CORTO_SOURCE_PATH src)
-SET(CORTO_HEADER_PATH include/corto)
+SET(CORTO_SOURCE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src)
+SET(CORTO_HEADER_PATH ${CMAKE_CURRENT_SOURCE_DIR}/include/corto)
 
 SET(LIB_HEADERS
 	${CORTO_HEADER_PATH}/bitstream.h
@@ -47,31 +49,15 @@ SET(EXE_HEADERS
 SET(CORTO_DEFINITIONS "")
 
 if(MSVC)
-	SET(CORTO_CFLAGS /nologo /W3)
-	LIST(APPEND CORTO_DEFINITIONS _CRT_SECURE_NO_DEPRECATE)
+	add_compile_options(/nologo /W3 -D_CRT_SECURE_NO_DEPRECATE)
 else()
-	SET(CORTO_CFLAGS -O2 -W -Wall -c -std=c++11 -pedantic)
+	add_compile_options(-Wall -pedantic)
 endif()
 
 ADD_LIBRARY(corto STATIC ${LIB_SOURCES} ${LIB_HEADERS})
 
-SET(CORTOLIB_CFLAGS ${CORTO_CFLAGS})
-
-if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
-	LIST(APPEND CORTOLIB_CFLAGS -fPIC)
-elseif(APPLE)
-	LIST(APPEND CORTOLIB_CFLAGS -fvisibility=hidden)
-	if(IOS)
-		LIST(APPEND CORTOLIB_CFLAGS -fembed-bitcode)
-		set_xcode_property(corto IPHONEOS_DEPLOYMENT_TARGET "9.2")
-	endif(IOS)
-endif()
-
 target_include_directories(corto PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(corto PRIVATE ${CORTO_HEADER_PATH})
-
-target_compile_definitions(corto PUBLIC ${CORTO_DEFINITIONS})
-target_compile_options    (corto PUBLIC ${CORTOLIB_CFLAGS})
 set_target_properties     (corto PROPERTIES DEBUG_POSTFIX "d")
 
 INSTALL(TARGETS corto
@@ -110,17 +96,9 @@ if (BUILD_CORTO_CODEC_UNITY)
 endif()
 if (BUILD_CORTO_EXE)
 	ADD_EXECUTABLE(cortoexe ${EXE_SOURCE} ${EXE_HEADERS})
-	SET(CORTOEXE_CFLAGS ${CORTO_CFLAGS})
-	if(APPLE)
-		if(IOS)
-			set_xcode_property(cortoexe IPHONEOS_DEPLOYMENT_TARGET "9.2")
-		endif()
-	endif()
 	target_include_directories(cortoexe PUBLIC ${CORTO_HEADER_PATH})
 	target_link_libraries(cortoexe PUBLIC corto)
-
-	target_compile_options    (cortoexe PUBLIC ${CORTOEXE_CFLAGS})
-	set_target_properties     (cortoexe PROPERTIES OUTPUT_NAME "corto")
+	set_target_properties(cortoexe PROPERTIES OUTPUT_NAME "corto")
 
 	INSTALL(TARGETS cortoexe
 		RUNTIME DESTINATION bin


### PR DESCRIPTION
some complier flags shouldn't be set directly, they are set by
cmake (optimization based on build type) or by the toolchain (ios)

"breaking change": default build is not optimized, because it is
Debug, as any other cmake project anyway

Tested with:
- Linux: gcc version 12.1.0 (Debian 12.1.0-8)
- Linux: Debian clang version 14.0.6-2
- macOS Intel: Apple clang version 13.1.6 (clang-1316.0.21.2.5)
- Windows 10: Visual Studio Community 2019 (MSVC 19.29.30146.0 and Windows SDK version 10.0.19041.0 to target Windows 10.0.19043)
- iOS: I suppose it work, on a old version I had to remove bitcode/ios target (this patch originates from it)

BTW: there are a lot of type conversion warnings spotted by MSVC