### PR TITLE
Add missing cstdint header in meshloader.h

### DIFF
--- a/src/meshloader.h
+++ b/src/meshloader.h
@@ -11,7 +11,7 @@ the Free Software Foundation; either version 3 of the License, or
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  You should have received 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  You should have received
 a copy of the GNU General Public License along with Corto.
 If not, see <http://www.gnu.org/licenses/>.
 */
@@ -19,6 +19,7 @@ If not, see <http://www.gnu.org/licenses/>.
 #ifndef CRT_MESHLOADER_H
 #define CRT_MESHLOADER_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>

--- a/src/objload.h
+++ b/src/objload.h
@@ -2,7 +2,7 @@
    All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met: 
+modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
    list of conditions and the following disclaimer.
@@ -25,6 +25,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
 #define OBJLOAD_H_
 
 #include <algorithm>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <sstream>

--- a/src/tinyply.h
+++ b/src/tinyply.h
@@ -9,6 +9,7 @@
 
 #include <vector>
 #include <algorithm>
+#include <cstdint>
 #include <string>
 #include <stdint.h>
 #include <map>


### PR DESCRIPTION
Hi @ponchio,

You just merged #44, but I guess you missed my comment about about the same issue in another place: https://github.com/cnr-isti-vclab/corto/pull/44#issuecomment-2018972154

Here is a fix :)